### PR TITLE
Don't clear frame buffer + call frame_complete_callback

### DIFF
--- a/src/ILI9488_t3.cpp
+++ b/src/ILI9488_t3.cpp
@@ -219,10 +219,10 @@ void ILI9488_t3::setFrameBuffer(RAFB *frame_buffer)
 {
 	#ifdef ENABLE_ILI9488_FRAMEBUFFER
 	_pfbtft = frame_buffer;
-	if (_pfbtft != NULL) {
-		// Frame buffer is color index only here...
-		memset(_pfbtft, 0, ILI9488_TFTHEIGHT*ILI9488_TFTWIDTH);
-	}
+//	if (_pfbtft != NULL) {
+//		// Frame buffer is color index only here...
+//		memset(_pfbtft, 0, ILI9488_TFTHEIGHT*ILI9488_TFTWIDTH);
+//	}
 
 	#endif	
 }
@@ -4307,6 +4307,7 @@ void ILI9488_t3::process_dma_interrupt(void) {
 
 		_dma_frame_count++;
 		//Serial.println("\nFrame complete");
+		if (_frame_complete_callback) (*_frame_complete_callback)();
 
 		if ((_dma_state & ILI9488_DMA_CONT) == 0) {
 			// We are in single refresh mode or the user has called cancel so


### PR DESCRIPTION
With ILI9341_t3n we removed the clearing of the buffer, to allow
people to swap buffers and the like.   Thought it would be good here
as well.

The 	void	setFrameCompleteCB(void (*pcb)(), bool fCallAlsoHalfDone=false);

Was not getting called in our normal case, where the updateScreenAsync code is converting RGB565 into RGB888 as part of the DMA/Interrupt code.